### PR TITLE
fix the NotifierBuilder::run flow 

### DIFF
--- a/include/inotify-cpp/Inotify.h
+++ b/include/inotify-cpp/Inotify.h
@@ -84,6 +84,7 @@ class Inotify {
   void setEventTimeout(std::chrono::milliseconds eventTimeout, std::function<void(FileSystemEvent)> onEventTimeout);
   boost::optional<FileSystemEvent> getNextEvent();
   void stop();
+  bool hasStopped();
 
 private:
   fs::path wdToPath(int wd);

--- a/include/inotify-cpp/NotifierBuilder.h
+++ b/include/inotify-cpp/NotifierBuilder.h
@@ -17,7 +17,7 @@ class NotifierBuilder {
     NotifierBuilder();
 
     auto run() -> void;
-    auto runOnce() -> bool;
+    auto runOnce() -> void;
     auto stop() -> void;
     auto watchPathRecursively(boost::filesystem::path path) -> NotifierBuilder&;
     auto watchFile(boost::filesystem::path file) -> NotifierBuilder&;

--- a/source/Inotify.cpp
+++ b/source/Inotify.cpp
@@ -262,6 +262,11 @@ void Inotify::stop()
     stopped = true;
 }
 
+bool Inotify::hasStopped()
+{
+  return stopped;
+}
+
 bool Inotify::isIgnored(std::string file)
 {
     for (unsigned i = 0; i < mOnceIgnoredDirectories.size(); ++i) {

--- a/source/Inotify.cpp
+++ b/source/Inotify.cpp
@@ -189,7 +189,7 @@ boost::optional<FileSystemEvent> Inotify::getNextEvent()
     // Read Events from fd into buffer
     while (mEventQueue.empty()) {
         length = 0;
-        memset(&buffer, 0, EVENT_BUF_LEN);
+        memset(buffer, '\0', sizeof(buffer));
         while (length <= 0 && !stopped) {
             std::this_thread::sleep_for(std::chrono::milliseconds(mThreadSleep));
 

--- a/test/unit/NotifierBuilderTests.cpp
+++ b/test/unit/NotifierBuilderTests.cpp
@@ -188,17 +188,6 @@ BOOST_FIXTURE_TEST_CASE(shouldUnwatchPath, NotifierBuilderTests)
     thread.join();
 }
 
-BOOST_FIXTURE_TEST_CASE(shouldThrowOnUnexpectedEvent, NotifierBuilderTests)
-{
-    auto notifier = BuildNotifier().watchFile(testFile_);
-
-    std::thread thread(
-        [&notifier]() { BOOST_CHECK_THROW(notifier.runOnce(), std::runtime_error); });
-
-    openFile(testFile_);
-    thread.join();
-}
-
 BOOST_FIXTURE_TEST_CASE(shouldCallUserDefinedUnexpectedExceptionObserver, NotifierBuilderTests)
 {
     std::promise<void> observerCalled;


### PR DESCRIPTION
The actual behavior: 

- The watcher was stopping when an unexpected event was found, the unexpected event in this case is any event not registered by the user.

The expected behavior:

- The watcher should continue observing the resource, it should stop only if the mInotify was flagged to stop, or if the event handler explicitly stop the watcher telling the mInotify to stop or throwing an exception.