### PR TITLE
Add inotify cmake config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 CMakeCache.txt
 **/**/CMakeFiles
 **/**/Makefile
-**/**/*.cmake
 example/inotify_example
 source/libinotify-cpp.a
 test/unit/inotify_unit_test

--- a/src/inotify-cppConfig.cmake
+++ b/src/inotify-cppConfig.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Boost 1.54.0)
+include("${CMAKE_CURRENT_LIST_DIR}/inotify-cppTargets.cmake")


### PR DESCRIPTION
The cmake config file was not added on modernizing the cmake files. The reason was a line in the gitignore file.