### PR TITLE
std and boost filesystem support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,33 @@
 cmake_minimum_required(VERSION 3.8)
 project(inotify-cpp)
 
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(BUILD_EXAMPLE "Build inotify-cpp example program" ON)
 option(BUILD_TEST "Build inotify-cpp unittest program" ON)
 option(BUILD_SHARED_LIBS "Build inotify-cpp as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build inotify-cpp as a static library" OFF)
+option(USE_BOOST_FILESYSTEM "Build with boost::filesystem" OFF)
+
+if(USE_BOOST_FILESYSTEM)
+    list(APPEND USED_BOOST_LIBS filesystem)
+endif()
+if(BUILD_TEST)
+    list(APPEND USED_BOOST_LIBS unit_test_framework)
+endif()
+
+find_package(Boost 1.54.0 COMPONENTS ${USED_BOOST_LIBS} REQUIRED)
+
+add_library(inotify-filesystem-adapter INTERFACE)
+if(CMAKE_CXX_STANDARD LESS 17 OR USE_BOOST_FILESYSTEM)
+    add_definitions(-DUSE_BOOST_FILESYSTEM)
+    target_link_libraries(inotify-filesystem-adapter INTERFACE Boost::filesystem)
+else()
+    target_link_libraries(inotify-filesystem-adapter INTERFACE stdc++fs)
+endif()
 
 add_subdirectory(src)
 
@@ -26,4 +49,6 @@ message(STATUS "  Build shared libs  .............. : ${BUILD_SHARED_LIBS}")
 message(STATUS "  Build static libs  .............. : ${BUILD_STATIC_LIBS}")
 message(STATUS "  Build example  .................. : ${BUILD_EXAMPLE}")
 message(STATUS "  Build test ...................... : ${BUILD_TEST}")
+message(STATUS "  Build c++ standard .............. : ${CMAKE_CXX_STANDARD}")
+message(STATUS "  Build with boost::filesystem .... : ${USE_BOOST_FILESYSTEM}")
 message(STATUS "")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,15 +9,6 @@ if(NOT TARGET inotify-cpp::inotify-cpp)
 endif()
 
 ###############################################################################
-# Boost
-###############################################################################
-find_package(
-        Boost 1.54.0
-        COMPONENTS unit_test_framework system
-        REQUIRED
-)
-
-###############################################################################
 # Thread
 ###############################################################################
 find_package(Threads)
@@ -26,7 +17,6 @@ find_package(Threads)
 # Target
 ###############################################################################
 add_executable(inotify_example main.cpp)
-target_compile_features(inotify_example PRIVATE cxx_std_17)
 target_link_libraries(inotify_example
         PRIVATE
         inotify-cpp::inotify-cpp

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char** argv)
     }
 
     // Parse the directory to watch
-    stdx::filesystem::path path(argv[1]);
+    inotifypp::filesystem::path path(argv[1]);
 
     // Set the event handler which will be used to process particular events
     auto handleNotification = [&](Notification notification) {

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,6 +1,5 @@
 #include <inotify-cpp/NotifierBuilder.h>
-
-#include <filesystem>
+#include <inotify-cpp/FileSystemAdapter.h>
 
 #include <iostream>
 #include <thread>
@@ -16,7 +15,7 @@ int main(int argc, char** argv)
     }
 
     // Parse the directory to watch
-    std::filesystem::path path(argv[1]);
+    stdx::filesystem::path path(argv[1]);
 
     // Set the event handler which will be used to process particular events
     auto handleNotification = [&](Notification notification) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,12 +12,6 @@ cmake_minimum_required(VERSION 3.8)
 project(${LIB_NAME} VERSION 0.2.0)
 include(GNUInstallDirs)
 
-# dependencies
-find_package(
-        Boost 1.54.0
-        REQUIRED
-)
-
 macro(configure_target target)
         set_target_properties(${target} PROPERTIES
                 LINKER_LANGUAGE CXX
@@ -39,7 +33,8 @@ macro(configure_target target)
         target_include_directories(${target} PUBLIC
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                 $<INSTALL_INTERFACE:include>)
-        target_compile_features(${target} PRIVATE cxx_std_17)
+        target_link_libraries(${target} PUBLIC inotify-filesystem-adapter)
+
 endmacro(configure_target target)
 
 # library definition

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,10 @@ macro(configure_target target)
 
 endmacro(configure_target target)
 
+# add export for adapter
+install(TARGETS inotify-filesystem-adapter EXPORT inotify-filesystem-adapterExport)
+install(EXPORT inotify-filesystem-adapterExport DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
 # library definition
 if(BUILD_SHARED_LIBS)
         add_library(${LIB_NAME}-shared SHARED ${LIB_SRCS} ${LIB_HEADER})

--- a/src/FileSystemEvent.cpp
+++ b/src/FileSystemEvent.cpp
@@ -6,7 +6,7 @@ namespace inotify {
 FileSystemEvent::FileSystemEvent(
     const int wd,
     uint32_t mask,
-    const stdx::filesystem::path& path,
+    const inotifypp::filesystem::path& path,
     const std::chrono::steady_clock::time_point& eventTime)
     : wd(wd)
     , mask(mask)

--- a/src/FileSystemEvent.cpp
+++ b/src/FileSystemEvent.cpp
@@ -6,7 +6,7 @@ namespace inotify {
 FileSystemEvent::FileSystemEvent(
     const int wd,
     uint32_t mask,
-    const std::filesystem::path& path,
+    const stdx::filesystem::path& path,
     const std::chrono::steady_clock::time_point& eventTime)
     : wd(wd)
     , mask(mask)

--- a/src/Inotify.cpp
+++ b/src/Inotify.cpp
@@ -2,7 +2,6 @@
 #include <inotify-cpp/Inotify.h>
 
 #include <iostream>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -10,7 +9,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-namespace fs = std::filesystem;
+namespace fs = stdx::filesystem;
 
 namespace inotify {
 
@@ -98,13 +97,13 @@ Inotify::~Inotify()
  */
 void Inotify::watchDirectoryRecursively(fs::path path)
 {
-    std::vector<std::filesystem::path> paths;
+    std::vector<fs::path> paths;
 
     if (fs::exists(path)) {
         paths.push_back(path);
 
         if (fs::is_directory(path)) {
-            std::error_code ec;
+            stdx::error_code ec;
             fs::recursive_directory_iterator it(
                 path, fs::directory_options::follow_directory_symlink, ec);
             fs::recursive_directory_iterator end;
@@ -236,7 +235,7 @@ void Inotify::setEventTimeout(
  * @return A new FileSystemEvent
  *
  */
-std::optional<FileSystemEvent> Inotify::getNextEvent()
+stdx::optional<FileSystemEvent> Inotify::getNextEvent()
 {
     std::vector<FileSystemEvent> newEvents;
 
@@ -247,7 +246,7 @@ std::optional<FileSystemEvent> Inotify::getNextEvent()
     }
 
     if (mStopped) {
-        return std::nullopt;
+        return stdx::nullopt();
     }
 
     auto event = mEventQueue.front();

--- a/src/Inotify.cpp
+++ b/src/Inotify.cpp
@@ -9,7 +9,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-namespace fs = stdx::filesystem;
+namespace fs = inotifypp::filesystem;
 
 namespace inotify {
 
@@ -103,7 +103,7 @@ void Inotify::watchDirectoryRecursively(fs::path path)
         paths.push_back(path);
 
         if (fs::is_directory(path)) {
-            stdx::error_code ec;
+            inotifypp::error_code ec;
             fs::recursive_directory_iterator it(
                 path, fs::directory_options::follow_directory_symlink, ec);
             fs::recursive_directory_iterator end;
@@ -235,7 +235,7 @@ void Inotify::setEventTimeout(
  * @return A new FileSystemEvent
  *
  */
-stdx::optional<FileSystemEvent> Inotify::getNextEvent()
+inotifypp::optional<FileSystemEvent> Inotify::getNextEvent()
 {
     std::vector<FileSystemEvent> newEvents;
 
@@ -246,7 +246,7 @@ stdx::optional<FileSystemEvent> Inotify::getNextEvent()
     }
 
     if (mStopped) {
-        return stdx::nullopt();
+        return inotifypp::nullopt();
     }
 
     auto event = mEventQueue.front();

--- a/src/Notification.cpp
+++ b/src/Notification.cpp
@@ -4,7 +4,7 @@ namespace inotify {
 
 Notification::Notification(
     const Event& event,
-    const std::filesystem::path& path,
+    const stdx::filesystem::path& path,
     std::chrono::steady_clock::time_point time)
     : event(event)
     , path(path)

--- a/src/Notification.cpp
+++ b/src/Notification.cpp
@@ -4,7 +4,7 @@ namespace inotify {
 
 Notification::Notification(
     const Event& event,
-    const stdx::filesystem::path& path,
+    const inotifypp::filesystem::path& path,
     std::chrono::steady_clock::time_point time)
     : event(event)
     , path(path)

--- a/src/NotifierBuilder.cpp
+++ b/src/NotifierBuilder.cpp
@@ -13,31 +13,31 @@ NotifierBuilder BuildNotifier()
     return {};
 }
 
-auto NotifierBuilder::watchPathRecursively(stdx::filesystem::path path) -> NotifierBuilder&
+auto NotifierBuilder::watchPathRecursively(inotifypp::filesystem::path path) -> NotifierBuilder&
 {
     mInotify->watchDirectoryRecursively(path);
     return *this;
 }
 
-auto NotifierBuilder::watchFile(stdx::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::watchFile(inotifypp::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->watchFile(file);
     return *this;
 }
 
-auto NotifierBuilder::unwatchFile(stdx::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::unwatchFile(inotifypp::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->unwatchFile(file);
     return *this;
 }
 
-auto NotifierBuilder::ignoreFileOnce(stdx::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::ignoreFileOnce(inotifypp::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->ignoreFileOnce(file.string());
     return *this;
 }
 
-auto NotifierBuilder::ignoreFile(stdx::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::ignoreFile(inotifypp::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->ignoreFile(file.string());
     return *this;

--- a/src/NotifierBuilder.cpp
+++ b/src/NotifierBuilder.cpp
@@ -13,31 +13,31 @@ NotifierBuilder BuildNotifier()
     return {};
 }
 
-auto NotifierBuilder::watchPathRecursively(std::filesystem::path path) -> NotifierBuilder&
+auto NotifierBuilder::watchPathRecursively(stdx::filesystem::path path) -> NotifierBuilder&
 {
     mInotify->watchDirectoryRecursively(path);
     return *this;
 }
 
-auto NotifierBuilder::watchFile(std::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::watchFile(stdx::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->watchFile(file);
     return *this;
 }
 
-auto NotifierBuilder::unwatchFile(std::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::unwatchFile(stdx::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->unwatchFile(file);
     return *this;
 }
 
-auto NotifierBuilder::ignoreFileOnce(std::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::ignoreFileOnce(stdx::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->ignoreFileOnce(file.string());
     return *this;
 }
 
-auto NotifierBuilder::ignoreFile(std::filesystem::path file) -> NotifierBuilder&
+auto NotifierBuilder::ignoreFile(stdx::filesystem::path file) -> NotifierBuilder&
 {
     mInotify->ignoreFile(file.string());
     return *this;

--- a/src/include/inotify-cpp/FileSystemAdapter.h
+++ b/src/include/inotify-cpp/FileSystemAdapter.h
@@ -5,7 +5,7 @@
 #include <filesystem>
 #include <optional>
 
-namespace stdx
+namespace inotifypp
 {
     namespace filesystem = std::filesystem;
 
@@ -23,7 +23,7 @@ namespace stdx
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 
-namespace stdx
+namespace inotifypp
 {
     namespace filesystem = boost::filesystem;
 

--- a/src/include/inotify-cpp/FileSystemAdapter.h
+++ b/src/include/inotify-cpp/FileSystemAdapter.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#if __cplusplus >= 201703L && !defined(USE_BOOST_FILESYSTEM)
+
+#include <filesystem>
+#include <optional>
+
+namespace stdx
+{
+    namespace filesystem = std::filesystem;
+
+    using error_code = std::error_code;
+
+    template<typename T>
+    using optional = std::optional<T>;
+
+    inline constexpr auto nullopt() { return std::nullopt; };
+
+}
+
+#else
+
+#include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
+
+namespace stdx
+{
+    namespace filesystem = boost::filesystem;
+
+    using error_code = boost::system::error_code;
+
+    template<typename T>
+    using optional = boost::optional<T>;
+
+    inline constexpr boost::none_t nullopt() { return boost::none; };
+}
+
+#endif

--- a/src/include/inotify-cpp/FileSystemEvent.h
+++ b/src/include/inotify-cpp/FileSystemEvent.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <filesystem>
+#include <inotify-cpp/FileSystemAdapter.h>
 
 #include <chrono>
 #include <string>
@@ -10,7 +10,7 @@ class FileSystemEvent {
     FileSystemEvent(
         int wd,
         uint32_t mask,
-        const std::filesystem::path& path,
+        const stdx::filesystem::path& path,
         const std::chrono::steady_clock::time_point& eventTime);
 
     ~FileSystemEvent();
@@ -18,7 +18,7 @@ class FileSystemEvent {
   public:
     int wd;
     uint32_t mask;
-    std::filesystem::path path;
+    stdx::filesystem::path path;
     std::chrono::steady_clock::time_point eventTime;
 };
 }

--- a/src/include/inotify-cpp/FileSystemEvent.h
+++ b/src/include/inotify-cpp/FileSystemEvent.h
@@ -10,7 +10,7 @@ class FileSystemEvent {
     FileSystemEvent(
         int wd,
         uint32_t mask,
-        const stdx::filesystem::path& path,
+        const inotifypp::filesystem::path& path,
         const std::chrono::steady_clock::time_point& eventTime);
 
     ~FileSystemEvent();
@@ -18,7 +18,7 @@ class FileSystemEvent {
   public:
     int wd;
     uint32_t mask;
-    stdx::filesystem::path path;
+    inotifypp::filesystem::path path;
     std::chrono::steady_clock::time_point eventTime;
 };
 }

--- a/src/include/inotify-cpp/Inotify.h
+++ b/src/include/inotify-cpp/Inotify.h
@@ -78,20 +78,20 @@ class Inotify {
  public:
   Inotify();
   ~Inotify();
-  void watchDirectoryRecursively(stdx::filesystem::path path);
-  void watchFile(stdx::filesystem::path file);
-  void unwatchFile(stdx::filesystem::path file);
-  void ignoreFileOnce(stdx::filesystem::path file);
-  void ignoreFile(stdx::filesystem::path file);
+  void watchDirectoryRecursively(inotifypp::filesystem::path path);
+  void watchFile(inotifypp::filesystem::path file);
+  void unwatchFile(inotifypp::filesystem::path file);
+  void ignoreFileOnce(inotifypp::filesystem::path file);
+  void ignoreFile(inotifypp::filesystem::path file);
   void setEventMask(uint32_t eventMask);
   uint32_t getEventMask();
   void setEventTimeout(std::chrono::milliseconds eventTimeout, std::function<void(FileSystemEvent)> onEventTimeout);
-  stdx::optional<FileSystemEvent> getNextEvent();
+  inotifypp::optional<FileSystemEvent> getNextEvent();
   void stop();
   bool hasStopped();
 
 private:
-  stdx::filesystem::path wdToPath(int wd);
+  inotifypp::filesystem::path wdToPath(int wd);
   bool isIgnored(std::string file);
   bool isOnTimeout(const std::chrono::steady_clock::time_point &eventTime);
   void removeWatch(int wd);
@@ -109,7 +109,7 @@ private:
   std::vector<std::string> mIgnoredDirectories;
   std::vector<std::string> mOnceIgnoredDirectories;
   std::queue<FileSystemEvent> mEventQueue;
-  boost::bimap<int, stdx::filesystem::path> mDirectorieMap;
+  boost::bimap<int, inotifypp::filesystem::path> mDirectorieMap;
   int mInotifyFd;
   std::atomic<bool> mStopped;
   int mEpollFd;

--- a/src/include/inotify-cpp/Inotify.h
+++ b/src/include/inotify-cpp/Inotify.h
@@ -11,10 +11,8 @@
 #include <chrono>
 #include <errno.h>
 #include <exception>
-#include <filesystem>
 #include <map>
 #include <memory>
-#include <optional>
 #include <queue>
 #include <sstream>
 #include <string>
@@ -25,12 +23,13 @@
 #include <vector>
 
 #include <inotify-cpp/FileSystemEvent.h>
+#include <inotify-cpp/FileSystemAdapter.h>
 
 #define MAX_EVENTS       4096
 /**
  * MAX_EPOLL_EVENTS is set to 1 since there exists
  * only one eventbuffer. The value can be increased
- * when readEventsIntoBuffer can handle multiple 
+ * when readEventsIntoBuffer can handle multiple
  * epoll events.
  */
 #define MAX_EPOLL_EVENTS 1
@@ -79,20 +78,20 @@ class Inotify {
  public:
   Inotify();
   ~Inotify();
-  void watchDirectoryRecursively(std::filesystem::path path);
-  void watchFile(std::filesystem::path file);
-  void unwatchFile(std::filesystem::path file);
-  void ignoreFileOnce(std::filesystem::path file);
-  void ignoreFile(std::filesystem::path file);
+  void watchDirectoryRecursively(stdx::filesystem::path path);
+  void watchFile(stdx::filesystem::path file);
+  void unwatchFile(stdx::filesystem::path file);
+  void ignoreFileOnce(stdx::filesystem::path file);
+  void ignoreFile(stdx::filesystem::path file);
   void setEventMask(uint32_t eventMask);
   uint32_t getEventMask();
   void setEventTimeout(std::chrono::milliseconds eventTimeout, std::function<void(FileSystemEvent)> onEventTimeout);
-  std::optional<FileSystemEvent> getNextEvent();
+  stdx::optional<FileSystemEvent> getNextEvent();
   void stop();
   bool hasStopped();
 
 private:
-  std::filesystem::path wdToPath(int wd);
+  stdx::filesystem::path wdToPath(int wd);
   bool isIgnored(std::string file);
   bool isOnTimeout(const std::chrono::steady_clock::time_point &eventTime);
   void removeWatch(int wd);
@@ -110,7 +109,7 @@ private:
   std::vector<std::string> mIgnoredDirectories;
   std::vector<std::string> mOnceIgnoredDirectories;
   std::queue<FileSystemEvent> mEventQueue;
-  boost::bimap<int, std::filesystem::path> mDirectorieMap;
+  boost::bimap<int, stdx::filesystem::path> mDirectorieMap;
   int mInotifyFd;
   std::atomic<bool> mStopped;
   int mEpollFd;

--- a/src/include/inotify-cpp/Notification.h
+++ b/src/include/inotify-cpp/Notification.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <inotify-cpp/Event.h>
-
-#include <filesystem>
+#include <inotify-cpp/FileSystemAdapter.h>
 
 #include <chrono>
 
@@ -12,12 +11,12 @@ class Notification {
   public:
     Notification(
         const Event& event,
-        const std::filesystem::path& path,
+        const stdx::filesystem::path& path,
         std::chrono::steady_clock::time_point time);
 
   public:
     const Event event;
-    const std::filesystem::path path;
+    const stdx::filesystem::path path;
     const std::chrono::steady_clock::time_point time;
 };
 }

--- a/src/include/inotify-cpp/Notification.h
+++ b/src/include/inotify-cpp/Notification.h
@@ -11,12 +11,12 @@ class Notification {
   public:
     Notification(
         const Event& event,
-        const stdx::filesystem::path& path,
+        const inotifypp::filesystem::path& path,
         std::chrono::steady_clock::time_point time);
 
   public:
     const Event event;
-    const stdx::filesystem::path path;
+    const inotifypp::filesystem::path path;
     const std::chrono::steady_clock::time_point time;
 };
 }

--- a/src/include/inotify-cpp/NotifierBuilder.h
+++ b/src/include/inotify-cpp/NotifierBuilder.h
@@ -18,11 +18,11 @@ class NotifierBuilder {
     auto run() -> void;
     auto runOnce() -> void;
     auto stop() -> void;
-    auto watchPathRecursively(stdx::filesystem::path path) -> NotifierBuilder&;
-    auto watchFile(stdx::filesystem::path file) -> NotifierBuilder&;
-    auto unwatchFile(stdx::filesystem::path file) -> NotifierBuilder&;
-    auto ignoreFileOnce(stdx::filesystem::path file) -> NotifierBuilder&;
-    auto ignoreFile(stdx::filesystem::path file) -> NotifierBuilder&;
+    auto watchPathRecursively(inotifypp::filesystem::path path) -> NotifierBuilder&;
+    auto watchFile(inotifypp::filesystem::path file) -> NotifierBuilder&;
+    auto unwatchFile(inotifypp::filesystem::path file) -> NotifierBuilder&;
+    auto ignoreFileOnce(inotifypp::filesystem::path file) -> NotifierBuilder&;
+    auto ignoreFile(inotifypp::filesystem::path file) -> NotifierBuilder&;
     auto onEvent(Event event, EventObserver) -> NotifierBuilder&;
     auto onEvents(std::vector<Event> event, EventObserver) -> NotifierBuilder&;
     auto onUnexpectedEvent(EventObserver) -> NotifierBuilder&;

--- a/src/include/inotify-cpp/NotifierBuilder.h
+++ b/src/include/inotify-cpp/NotifierBuilder.h
@@ -2,8 +2,7 @@
 
 #include <inotify-cpp/Inotify.h>
 #include <inotify-cpp/Notification.h>
-
-#include <filesystem>
+#include <inotify-cpp/FileSystemAdapter.h>
 
 #include <memory>
 #include <string>
@@ -19,11 +18,11 @@ class NotifierBuilder {
     auto run() -> void;
     auto runOnce() -> void;
     auto stop() -> void;
-    auto watchPathRecursively(std::filesystem::path path) -> NotifierBuilder&;
-    auto watchFile(std::filesystem::path file) -> NotifierBuilder&;
-    auto unwatchFile(std::filesystem::path file) -> NotifierBuilder&;
-    auto ignoreFileOnce(std::filesystem::path file) -> NotifierBuilder&;
-    auto ignoreFile(std::filesystem::path file) -> NotifierBuilder&;
+    auto watchPathRecursively(stdx::filesystem::path path) -> NotifierBuilder&;
+    auto watchFile(stdx::filesystem::path file) -> NotifierBuilder&;
+    auto unwatchFile(stdx::filesystem::path file) -> NotifierBuilder&;
+    auto ignoreFileOnce(stdx::filesystem::path file) -> NotifierBuilder&;
+    auto ignoreFile(stdx::filesystem::path file) -> NotifierBuilder&;
     auto onEvent(Event event, EventObserver) -> NotifierBuilder&;
     auto onEvents(std::vector<Event> event, EventObserver) -> NotifierBuilder&;
     auto onUnexpectedEvent(EventObserver) -> NotifierBuilder&;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -9,15 +9,6 @@ if(NOT TARGET inotify-cpp::inotify-cpp)
 endif()
 
 ###############################################################################
-# Boost
-###############################################################################
-find_package(
-        Boost 1.54.0
-        COMPONENTS unit_test_framework
-        REQUIRED
-)
-
-###############################################################################
 # Thread
 ###############################################################################
 find_package(Threads)
@@ -26,7 +17,6 @@ find_package(Threads)
 # Test
 ###############################################################################
 add_executable(inotify_unit_test main.cpp NotifierBuilderTests.cpp EventTests.cpp)
-target_compile_features(inotify_unit_test PRIVATE cxx_std_17)
 target_link_libraries(inotify_unit_test
         PRIVATE
           inotify-cpp::inotify-cpp

--- a/test/unit/NotifierBuilderTests.cpp
+++ b/test/unit/NotifierBuilderTests.cpp
@@ -10,7 +10,7 @@
 
 using namespace inotify;
 
-void openFile(const stdx::filesystem::path& file)
+void openFile(const inotifypp::filesystem::path& file)
 {
     std::ifstream stream;
     stream.open(file.string(), std::ifstream::in);
@@ -18,7 +18,7 @@ void openFile(const stdx::filesystem::path& file)
     stream.close();
 }
 
-void createFile(const stdx::filesystem::path& file)
+void createFile(const inotifypp::filesystem::path& file)
 {
     std::ofstream stream(file.string());
 }
@@ -32,8 +32,8 @@ struct NotifierBuilderTests {
         , createdFile_(testDirectory_ / "created.txt")
         , timeout_(1)
     {
-        stdx::filesystem::create_directories(testDirectory_);
-        stdx::filesystem::create_directories(recursiveTestDirectory_);
+        inotifypp::filesystem::create_directories(testDirectory_);
+        inotifypp::filesystem::create_directories(recursiveTestDirectory_);
 
         createFile(testFile_);
         createFile(recursiveTestFile_);
@@ -41,14 +41,14 @@ struct NotifierBuilderTests {
 
     ~NotifierBuilderTests()
     {
-        stdx::filesystem::remove_all(testDirectory_);
+        inotifypp::filesystem::remove_all(testDirectory_);
     }
 
-    stdx::filesystem::path testDirectory_;
-    stdx::filesystem::path recursiveTestDirectory_;
-    stdx::filesystem::path testFile_;
-    stdx::filesystem::path recursiveTestFile_;
-    stdx::filesystem::path createdFile_;
+    inotifypp::filesystem::path testDirectory_;
+    inotifypp::filesystem::path recursiveTestDirectory_;
+    inotifypp::filesystem::path testFile_;
+    inotifypp::filesystem::path recursiveTestFile_;
+    inotifypp::filesystem::path createdFile_;
 
     std::chrono::seconds timeout_;
 
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE(shouldNotifyOnCombinedEvent, NotifierBuilderTests)
 
     std::thread thread([&notifier]() { notifier.runOnce(); });
 
-    stdx::filesystem::create_directories(testDirectory_ / "test");
+    inotifypp::filesystem::create_directories(testDirectory_ / "test");
 
     auto futureCombinedEvent = promisedCombinedEvent_.get_future();
     BOOST_CHECK(futureCombinedEvent.wait_for(timeout_) == std::future_status::ready);

--- a/test/unit/NotifierBuilderTests.cpp
+++ b/test/unit/NotifierBuilderTests.cpp
@@ -10,7 +10,7 @@
 
 using namespace inotify;
 
-void openFile(const std::filesystem::path& file)
+void openFile(const stdx::filesystem::path& file)
 {
     std::ifstream stream;
     stream.open(file.string(), std::ifstream::in);
@@ -18,9 +18,9 @@ void openFile(const std::filesystem::path& file)
     stream.close();
 }
 
-void createFile(const std::filesystem::path& file)
+void createFile(const stdx::filesystem::path& file)
 {
-    std::ofstream stream(file);
+    std::ofstream stream(file.string());
 }
 
 struct NotifierBuilderTests {
@@ -32,8 +32,8 @@ struct NotifierBuilderTests {
         , createdFile_(testDirectory_ / "created.txt")
         , timeout_(1)
     {
-        std::filesystem::create_directories(testDirectory_);
-        std::filesystem::create_directories(recursiveTestDirectory_);
+        stdx::filesystem::create_directories(testDirectory_);
+        stdx::filesystem::create_directories(recursiveTestDirectory_);
 
         createFile(testFile_);
         createFile(recursiveTestFile_);
@@ -41,14 +41,14 @@ struct NotifierBuilderTests {
 
     ~NotifierBuilderTests()
     {
-        std::filesystem::remove_all(testDirectory_);
+        stdx::filesystem::remove_all(testDirectory_);
     }
 
-    std::filesystem::path testDirectory_;
-    std::filesystem::path recursiveTestDirectory_;
-    std::filesystem::path testFile_;
-    std::filesystem::path recursiveTestFile_;
-    std::filesystem::path createdFile_;
+    stdx::filesystem::path testDirectory_;
+    stdx::filesystem::path recursiveTestDirectory_;
+    stdx::filesystem::path testFile_;
+    stdx::filesystem::path recursiveTestFile_;
+    stdx::filesystem::path createdFile_;
 
     std::chrono::seconds timeout_;
 
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE(shouldNotifyOnCombinedEvent, NotifierBuilderTests)
 
     std::thread thread([&notifier]() { notifier.runOnce(); });
 
-    std::filesystem::create_directories(testDirectory_ / "test");
+    stdx::filesystem::create_directories(testDirectory_ / "test");
 
     auto futureCombinedEvent = promisedCombinedEvent_.get_future();
     BOOST_CHECK(futureCombinedEvent.wait_for(timeout_) == std::future_status::ready);


### PR DESCRIPTION
Hello, Erik.

Thank you for your library.
I suggest to support both boost::filesystem & std::filesystem which make your library more "soft" or flexible.
For that I've re-worked std::filesystem support to allow use with older compilers and standards.
This PR can be used as reference or just merged as is.

Now supported any combinations for it
`cmake -S. -Bbuild` - will use c++17 by default and std::filesystem
`cmake -S. -Bbuild -DCMAKE_CXX_STANDARD=11 -DUSE_BOOST_FILESYSTEM=ON` -will use c++11 and boost::filesystem
`cmake -S. -Bbuild -DUSE_BOOST_FILESYSTEM=ON` - will use c++17 but boost::filesystem
